### PR TITLE
modify snapshot's epoch

### DIFF
--- a/lib/model_serializer.py
+++ b/lib/model_serializer.py
@@ -6,7 +6,7 @@ def save_snapshots(epoch, model, optimizer, scheduler, path):
     else:
         module = model
     torch.save({
-        'epoch': epoch,
+        'epoch': epoch + 1,
         'model': module.state_dict(),
         'optimizer': optimizer.state_dict(),
         'scheduler': scheduler.state_dict()


### PR DESCRIPTION
I appreciate your refactoring and I believe your code is clear.
Currently I am trying to train M2Det using an original dataset.

When saving a snapshot in epoch n, the resume should start from epoch (n+1).